### PR TITLE
Fixed NewLimiter call

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ func main() {
 	e := echo.New()
 
 	// Create a limiter struct.
-	limiter := tollbooth.NewLimiter(1, time.Second, nil)
+	limiter := tollbooth.NewLimiter(1, nil)
 
 	e.Get("/", echo.HandlerFunc(func(c echo.Context) error {
 		return c.String("Hello, World!", 200)


### PR DESCRIPTION
Since TTL was removed from NewLimiter with didip/tollbooth@49a474e4248186bbc2db5cb28391ed23e7764007 this example should be changed too.